### PR TITLE
feat: add mine.worktree-rebase skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this Claudefiles repository are documented here.
 ## 2026-03-12
 
 ### Added
-- `mine.worktree-rebase` skill — detects when a worktree was created while the parent repo was on a feature branch and rebases onto it after confirmation (#74)
-
-
+- `mine.worktree-rebase` skill — detects when a worktree's parent repo is currently on a feature branch and rebases onto it after confirmation (#74)
 
 ### Changed
 - `mine.create-pr` now detects the related issue from the branch name and commit messages and appends `Closes #N` to the PR body automatically (GitHub only) (#73)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ All skills and commands use a `mine.` prefix to avoid collisions with other sour
 | `mine.tool-gaps` | Surface missing CLI functionality and unscripted recurring patterns by mining session history for workarounds |
 | `mine.ux-antipatterns` | Detect UX anti-patterns -- layout shifts, missing feedback, broken forms, a11y gaps |
 | `mine.wp` | WP lane management — move work packages between lanes, view kanban, list WPs |
-| `mine.worktree-rebase` | Detect when parent repo was on a feature branch at worktree creation and rebase this worktree branch onto it |
+| `mine.worktree-rebase` | Detect when the parent repo is currently on a feature branch and rebase this worktree branch onto it (run immediately after creating the worktree) |
 
 ### Commands (11)
 

--- a/rules/common/capabilities.md
+++ b/rules/common/capabilities.md
@@ -359,7 +359,7 @@ Use `git rev-parse --git-dir` to check if you're already in a worktree (output c
 
 ### /mine.worktree-rebase
 
-Detect when the parent repo was on a feature branch at worktree creation time and offer to rebase the worktree branch onto it. No-op if the parent was already on the default branch.
+Detect when the parent repo is currently on a feature branch and offer to rebase the worktree branch onto it. No-op if the parent is already on the default branch.
 
 ### /mine.issues
 

--- a/rules/common/worktrees.md
+++ b/rules/common/worktrees.md
@@ -64,4 +64,4 @@ If `claude --worktree` was invoked while the parent repo was on a feature branch
 /mine.worktree-rebase
 ```
 
-This detects the original branch, shows you what it will do, and performs `git rebase --onto <orig-branch> origin/<default>` after confirmation.
+This detects the parent repo's current branch, shows you what it will do, and performs `git rebase --onto <orig-branch> origin/<default>` after confirmation. Run it immediately after entering the new worktree, before the parent repo's branch changes.

--- a/skills/mine.worktree-rebase/SKILL.md
+++ b/skills/mine.worktree-rebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mine.worktree-rebase
-description: Detect when the parent repo was on a feature branch at worktree creation and offer to rebase this worktree branch onto it.
+description: Detect when the parent repo is currently on a feature branch and offer to rebase this worktree branch onto it.
 user-invokable: true
 ---
 
@@ -12,7 +12,7 @@ user-invokable: true
 
 ## Your task
 
-Detect whether this worktree was created while the parent repo was on a non-default branch, and offer to rebase accordingly.
+Detect whether the parent repo is currently on a non-default branch, and offer to rebase this worktree onto it. For best results, run this immediately after entering a new worktree.
 
 ### Phase 1 — Verify you are inside a worktree
 
@@ -30,15 +30,15 @@ git rev-parse --git-common-dir
 ```
 Note the output — call it `<common-git-dir>`.
 
-**Step 2** — Derive the original repo root (the parent of the `.git` dir):
+**Step 2** — Derive the original repo root. Use the exact path from Step 1 — substitute it directly (no pipes, no xargs — handles spaces in paths correctly):
 ```bash
-git rev-parse --git-common-dir | xargs dirname
+dirname <common-git-dir>
 ```
-Note the output — call it `<orig-root>`.
+For example, if Step 1 returned `/home/jessica/Claudefiles/.git`, run `dirname /home/jessica/Claudefiles/.git`. Note the output — call it `<orig-root>`.
 
-**Step 3** — Read the current branch of the original repo:
+**Step 3** — Read the current branch of the original repo. Use the exact path from Step 2:
 ```bash
-git rev-parse --git-common-dir | xargs -I {} git -C {}/../ symbolic-ref --short HEAD 2>/dev/null
+git -C <orig-root> symbolic-ref --short HEAD 2>/dev/null
 ```
 - If this exits 0 and prints a branch name → that is `<orig-branch>`.
 - If this exits non-zero (detached HEAD or error) → treat `<orig-branch>` as the default branch (no rebase needed).
@@ -49,7 +49,7 @@ Compare `<orig-branch>` to the default branch from Context.
 
 If they are the same → stop with a friendly message:
 
-> The parent repo was already on `<default-branch>` when this worktree was created. No rebase needed.
+> The parent repo is currently on `<default-branch>`. No rebase needed.
 
 ### Phase 4 — Show the situation and confirm
 
@@ -65,7 +65,7 @@ Rebasing will move this worktree's commits on top of `<orig-branch>`.
 ```
 
 Ask the user to confirm using AskUserQuestion:
-- question: `Rebase \`<current-branch>\` onto \`<orig-branch>\`?`
+- question: "Rebase `<current-branch>` onto `<orig-branch>`?"
 - header: `Worktree rebase`
 - options:
   - `Yes — rebase onto <orig-branch>` (description: `git rebase --onto <orig-branch> origin/<default-branch>`)


### PR DESCRIPTION
## Summary

- Adds `mine.worktree-rebase` skill to fix the annoyance where `claude --worktree` always branches from `origin/main` regardless of your current branch (upstream issue [anthropics/claude-code#27134](https://github.com/anthropics/claude-code/issues/27134))
- After entering a new worktree, run `/mine.worktree-rebase` — it detects the parent repo's branch, shows what it will do, and rebases after confirmation
- Updates `rules/common/capabilities.md` and `rules/common/worktrees.md` so the skill is discoverable via intent routing and documented at the point of need
