### PR TITLE
fix: spec-helper find_repo_root supports monorepo nested design/specs/

### DIFF
--- a/packages/spec-helper/src/spec_helper/filesystem.py
+++ b/packages/spec-helper/src/spec_helper/filesystem.py
@@ -41,15 +41,21 @@ def find_git_root() -> Path:
 
 
 def find_repo_root() -> Path:
-    """Walk up from cwd to find a git repo containing design/specs/.
+    """Walk up from cwd to find the nearest directory containing design/specs/.
 
+    Searches from cwd upward, stopping at the git root. This handles monorepos
+    where design/specs/ lives in a subdirectory (e.g., apps/my-app/design/specs/).
     Requires .git in ancestry — never falls back to cwd.
     """
-    root = find_git_root()
-    if (root / "design" / "specs").exists():
-        return root
+    git_root = find_git_root()
+    cwd = Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        if (parent / "design" / "specs").exists():
+            return parent
+        if parent == git_root:
+            break
     die(
-        f"Git repository at {root} has no design/specs/ directory. "
+        f"No design/specs/ directory found between cwd and git root ({git_root}). "
         f"Run 'spec-helper init <slug>' to create a feature."
     )
 

--- a/tests/test_spec_helper.py
+++ b/tests/test_spec_helper.py
@@ -278,6 +278,35 @@ class TestFindRepoRootWithGitAndSpecs:
         assert find_repo_root() == tmp_path
 
 
+class TestFindRepoRootMonorepo:
+    """Monorepo: design/specs/ nested inside a subdirectory, not at git root."""
+
+    def test_finds_nested_specs_from_app_dir(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        app = tmp_path / "apps" / "my-app"
+        (app / "design" / "specs").mkdir(parents=True)
+        monkeypatch.chdir(app)
+        assert find_repo_root() == app
+
+    def test_finds_nested_specs_from_deeper_subdir(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        app = tmp_path / "apps" / "my-app"
+        (app / "design" / "specs").mkdir(parents=True)
+        deep = app / "src" / "components"
+        deep.mkdir(parents=True)
+        monkeypatch.chdir(deep)
+        assert find_repo_root() == app
+
+    def test_prefers_nearest_specs_over_root(self, tmp_path, monkeypatch):
+        """When both git root and a subdirectory have design/specs/, use the nearest."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "design" / "specs").mkdir(parents=True)
+        app = tmp_path / "apps" / "my-app"
+        (app / "design" / "specs").mkdir(parents=True)
+        monkeypatch.chdir(app)
+        assert find_repo_root() == app
+
+
 class TestFindRepoRootNoGitDies:
     def test_no_git_dies(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

- `find_repo_root()` now walks up from cwd to find the **nearest** `design/specs/` directory, stopping at the git root — previously it only checked the git root itself
- Fixes `spec-helper wp-validate` (and all other commands) failing in monorepos where `design/specs/` lives inside an app subdirectory (e.g., `apps/lineage-tracker-app/design/specs/`)
- Adds 3 monorepo-specific tests (nested specs from app dir, from deeper subdir, prefers nearest over root)
