### PR TITLE
Remove stale pyright prerequisite check from installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this Claudefiles repository are documented here.
 ## 2026-04-11
 
 ### Removed
-- Pyright prerequisite check from `install.sh` — LSP plugin is disabled and the warning caused confusion
+- Pyright prerequisite check from `install.sh` — LSP plugin is disabled and the warning caused confusion (#211)
 
 ## 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this Claudefiles repository are documented here.
 
+## 2026-04-11
+
+### Removed
+- Pyright prerequisite check from `install.sh` — LSP plugin is disabled and the warning caused confusion
+
 ## 2026-04-10
 
 ### Changed

--- a/install.sh
+++ b/install.sh
@@ -224,11 +224,3 @@ if [ ${#stale_links[@]} -gt 0 ]; then
 fi
 
 echo "Claudefiles installed to $CLAUDE_DIR"
-
-# Prerequisite checks
-if ! command -v pyright &> /dev/null; then
-  echo "" >&2
-  echo "note: pyright not found — LSP features (go-to-definition, find-references, hover)" >&2
-  echo "      will not work until you install it:" >&2
-  echo "        npm install -g pyright" >&2
-fi


### PR DESCRIPTION
## Summary

- Remove the pyright prerequisite check from `install.sh` — the LSP plugin has been disabled and this warning ("pyright not found") just causes confusion since LSP features are no longer used
