### PR TITLE
fix: add hookEventName to PreToolUse hook output

### DIFF
--- a/scripts/hooks/sudo-poll.sh
+++ b/scripts/hooks/sudo-poll.sh
@@ -49,7 +49,7 @@ fi
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
 
 # Not a sudo command — no opinion, pass through
-if ! printf '%s' "$COMMAND" | grep -qw 'sudo'; then
+if ! printf '%s' "$COMMAND" | grep -q 'sudo '; then
   exit 0
 fi
 

--- a/scripts/hooks/sudo-poll.sh
+++ b/scripts/hooks/sudo-poll.sh
@@ -42,7 +42,7 @@ INPUT=$(cat)
 # jq is required to parse hook input — fail clearly, not cryptically
 if ! command -v jq > /dev/null 2>&1; then
   printf 'ERROR: jq is required by scripts/hooks/sudo-poll.sh. Install jq or remove this hook.\n' >&2
-  printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"jq is required by scripts/hooks/sudo-poll.sh. Install jq or remove this hook."}}'
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"jq is required by scripts/hooks/sudo-poll.sh. Install jq or remove this hook."}}'
   exit 0
 fi
 
@@ -55,13 +55,13 @@ fi
 
 allow() {
   jq -cn --arg reason "$1" \
-    '{"hookSpecificOutput":{"permissionDecision":"allow","permissionDecisionReason":$reason}}'
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":$reason}}'
   exit 0
 }
 
 deny() {
   jq -cn --arg reason "$1" \
-    '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":$reason}}'
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'
   exit 0
 }
 


### PR DESCRIPTION
## Changes

**1. Add `hookEventName` to PreToolUse hook output**

Claude Code now requires `hookEventName` in `hookSpecificOutput` for hook JSON output validation. Without it, every Bash command triggers:

```
Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"
```

Adds `"hookEventName":"PreToolUse"` to all three JSON output paths in the hook script:
- `allow()` function
- `deny()` function
- jq-missing fallback printf

**2. Tighten command detection to require trailing space**

The previous `grep -qw` pattern matched the keyword as a "word" anywhere in the command string, including in arguments like branch names (`fix/...-hook-schema`) because `-` is not a word character. Changed to require a trailing space, which eliminates false positives on hyphenated strings while still matching all real invocations (`<cmd> rsync`, `<cmd> -v`, etc.).