### PR TITLE
feat(context-tier): add heartbeat to re-inject guidance every N tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this Claudefiles repository are documented here.
 
+## 2026-05-01
+
+### Added
+- `context-tier.sh` heartbeat — re-injects tier guidance every 25 tool calls (configurable via `CLAUDE_CONTEXT_HEARTBEAT`) to prevent fabricated context pressure during long orchestrations
+
 ## 2026-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this Claudefiles repository are documented here.
 ## 2026-05-01
 
 ### Added
-- `context-tier.sh` heartbeat — re-injects tier guidance every 25 tool calls (configurable via `CLAUDE_CONTEXT_HEARTBEAT`) to prevent fabricated context pressure during long orchestrations
+- `context-tier.sh` heartbeat — re-injects tier guidance every 25 tool calls (configurable via `CLAUDE_CONTEXT_HEARTBEAT`) to prevent fabricated context pressure during long orchestrations (#274)
 
 ## 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Event-driven scripts that run before/after tool calls.
 | `cm-memory-context` (package) | SessionStart (startup\|clear) | Load memory context into the session |
 | `cm-consolidation-check` (package) | SessionStart (startup\|clear) | Check if memory consolidation is needed |
 | `cm-clear-handoff` (package) | SessionEnd (clear) | Write a handoff note before `/clear` |
-| `context-tier.sh` | PreToolUse (*) | Inject context window tier guidance when usage crosses a threshold — prevents hallucinated context pressure |
+| `context-tier.sh` | PreToolUse (*) | Inject context window tier guidance on tier change or periodic heartbeat (every 25 calls) — prevents hallucinated context pressure |
 | `cm-memory-sync` (package) | Stop | Sync current session to the conversation database |
 
 > **Context tier setup:** The `context-tier.sh` hook reads a sidecar file written by `claude-context-writer`. To enable it, add `claude-context-writer` to your `statusLine.command` in settings — either by itself or in front of your existing command:

--- a/rules/common/performance.md
+++ b/rules/common/performance.md
@@ -6,7 +6,7 @@
 
 ## Context Window (CRITICAL)
 
-A PreToolUse hook (`context-tier.sh`) injects context usage tiers when they change. Follow the guidance in those messages. When no tier message is present, do not invent context pressure — any unprompted claim about context usage ("building up," "getting low," suggesting compaction) is a fabrication.
+A PreToolUse hook (`context-tier.sh`) injects context usage tiers when they change and re-injects periodically (every 25 tool calls) to keep guidance fresh. Follow the guidance in those messages. When no tier message is present, do not invent context pressure — any unprompted claim about context usage ("building up," "getting low," suggesting compaction) is a fabrication.
 
 If you think a task should be split across sessions, justify it on *quality* grounds (complexity, focus), never context pressure.
 

--- a/scripts/hooks/context-tier.sh
+++ b/scripts/hooks/context-tier.sh
@@ -88,11 +88,11 @@ elif [ "$count" -ge "$heartbeat_interval" ]; then
   count=0
 fi
 
-printf '%d' "$count" > "$counter_file" 2> /dev/null || true
+printf '%d' "$count" > "${counter_file}.tmp" 2> /dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2> /dev/null || true
 
 [ "$emit" = false ] && exit 0
 
 # Tier changed or heartbeat fired — update state and emit guidance
-printf '%s' "$tier" > "$tier_file" 2> /dev/null || true
+printf '%s' "$tier" > "${tier_file}.tmp" 2> /dev/null && mv -f "${tier_file}.tmp" "$tier_file" 2> /dev/null || true
 jq -cn --arg msg "$message" \
   '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$msg}}'

--- a/scripts/hooks/context-tier.sh
+++ b/scripts/hooks/context-tier.sh
@@ -2,9 +2,9 @@
 # PreToolUse hook: inject context window tier guidance
 #
 # Reads the sidecar file written by claude-context-writer (via statusLine),
-# computes a behavioral tier, and emits additionalContext only when the tier
-# changes. This prevents Claude from hallucinating context pressure at low
-# usage and provides actionable guidance at higher usage.
+# computes a behavioral tier, and emits additionalContext when the tier
+# changes or on a periodic heartbeat. This prevents Claude from hallucinating
+# context pressure at low usage and provides actionable guidance at higher usage.
 #
 # Tiers:
 #   low      (<25%)  — reassurance: continue working normally
@@ -12,6 +12,12 @@
 #   moderate (40-59%) — prefer subagents for large reads
 #   high     (60-79%) — finish current task, delegate exploratory work
 #   critical (80%+)   — compaction imminent, checkpoint or finish
+#
+# Heartbeat: even when the tier hasn't changed, re-inject the message every
+# N tool calls (default 25, override via CLAUDE_CONTEXT_HEARTBEAT). This
+# prevents the reassurance from scrolling out of context during long
+# orchestrations, which caused Claude to fabricate context pressure and skip
+# code reviews in practice.
 #
 # Hook wiring: add as a separate "PreToolUse" entry with matcher "*" in
 # settings.json so it fires before any tool call, not just Bash.
@@ -62,9 +68,31 @@ fi
 tier_file="/tmp/claude-context-tier-${session_id}.txt"
 last_tier="$(cat "$tier_file" 2> /dev/null)" || true
 
-[ "$tier" = "$last_tier" ] && exit 0
+# Heartbeat counter — re-inject even when tier is unchanged
+heartbeat_interval="${CLAUDE_CONTEXT_HEARTBEAT:-25}"
+case "$heartbeat_interval" in
+  '' | *[!0-9]* | 0) heartbeat_interval=25 ;;
+esac
+counter_file="/tmp/claude-context-calls-${session_id}.txt"
+count="$(cat "$counter_file" 2> /dev/null)" || true
+count="${count:-0}"
+case "$count" in *[!0-9]*) count=0 ;; esac
+count=$((count + 1))
 
-# Tier changed — update state and emit guidance
+emit=false
+if [ "$tier" != "$last_tier" ]; then
+  emit=true
+  count=0
+elif [ "$count" -ge "$heartbeat_interval" ]; then
+  emit=true
+  count=0
+fi
+
+printf '%d' "$count" > "$counter_file" 2> /dev/null || true
+
+[ "$emit" = false ] && exit 0
+
+# Tier changed or heartbeat fired — update state and emit guidance
 printf '%s' "$tier" > "$tier_file" 2> /dev/null || true
 jq -cn --arg msg "$message" \
   '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$msg}}'

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -854,14 +854,31 @@ def _write_tier(session_id: str, tier: str) -> Path:
 
 
 def _cleanup_context_tier(session_id: str) -> None:
-    """Remove sidecar and tier files for a session."""
+    """Remove sidecar, tier, and counter files for a session."""
     for pattern in (
         f"/tmp/claude-context-{session_id}.txt",
         f"/tmp/claude-context-tier-{session_id}.txt",
+        f"/tmp/claude-context-calls-{session_id}.txt",
     ):
         p = Path(pattern)
         if p.exists():
             p.unlink()
+
+
+def _write_counter(session_id: str, count: int) -> Path:
+    """Pre-seed the heartbeat counter file."""
+    p = Path(f"/tmp/claude-context-calls-{session_id}.txt")
+    p.write_text(str(count))
+    return p
+
+
+def _read_counter(session_id: str) -> int | None:
+    """Read the heartbeat counter; returns None if absent."""
+    p = Path(f"/tmp/claude-context-calls-{session_id}.txt")
+    if not p.exists():
+        return None
+    text = p.read_text().strip()
+    return int(text) if text else None
 
 
 def _make_context_tier_input(session_id: str) -> str:
@@ -869,14 +886,20 @@ def _make_context_tier_input(session_id: str) -> str:
     return json.dumps({"session_id": session_id})
 
 
-def _run_context_tier(session_id: str) -> subprocess.CompletedProcess:
+def _run_context_tier(
+    session_id: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
     """Run the context-tier hook with the given session_id."""
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [str(CONTEXT_TIER_HOOK)],
         input=_make_context_tier_input(session_id),
         capture_output=True,
         text=True,
-        env=os.environ.copy(),
+        env=env,
     )
 
 
@@ -909,7 +932,7 @@ class TestContextTierFirstCallEmits:
 
 
 class TestContextTierSameTierSuppressed:
-    """Repeat call at the same tier produces no output."""
+    """Repeat call at the same tier is suppressed (until heartbeat threshold)."""
 
     def test_context_tier_same_tier_silent(self):
         sid = _context_tier_session_id("same_tier")
@@ -1093,6 +1116,76 @@ class TestContextTierInvalidSidecar:
 
             assert result.returncode == 0
             assert result.stdout.strip() == ""
+        finally:
+            _cleanup_context_tier(sid)
+
+
+class TestContextTierHeartbeat:
+    """Heartbeat re-injects the message every N calls even without a tier change."""
+
+    def test_heartbeat_fires_at_threshold(self):
+        sid = _context_tier_session_id("hb_fire")
+        try:
+            _write_sidecar(sid, "15")
+            # First call emits (tier change from empty → low), resets counter to 0
+            result = _run_context_tier(sid, extra_env={"CLAUDE_CONTEXT_HEARTBEAT": "5"})
+            assert "low usage (15%)" in result.stdout
+
+            # Calls 2-5: suppressed (counter 1-4)
+            for _ in range(4):
+                result = _run_context_tier(
+                    sid, extra_env={"CLAUDE_CONTEXT_HEARTBEAT": "5"}
+                )
+                assert result.stdout.strip() == ""
+
+            # Call 6: heartbeat fires (counter hits 5)
+            result = _run_context_tier(sid, extra_env={"CLAUDE_CONTEXT_HEARTBEAT": "5"})
+            assert "low usage (15%)" in result.stdout
+            assert _read_counter(sid) == 0
+        finally:
+            _cleanup_context_tier(sid)
+
+    def test_tier_change_resets_counter(self):
+        sid = _context_tier_session_id("hb_reset")
+        try:
+            _write_sidecar(sid, "15")
+            _write_tier(sid, "low")
+            _write_counter(sid, 20)
+
+            # Tier change (low → moderate) should emit and reset counter
+            _write_sidecar(sid, "45")
+            result = _run_context_tier(sid)
+            assert "moderate usage (45%)" in result.stdout
+            assert _read_counter(sid) == 0
+        finally:
+            _cleanup_context_tier(sid)
+
+    def test_non_numeric_env_falls_back_to_default(self):
+        sid = _context_tier_session_id("hb_badenv")
+        try:
+            _write_sidecar(sid, "15")
+            _write_tier(sid, "low")
+            _write_counter(sid, 23)
+
+            # With bad env, interval falls back to 25; counter 23+1=24 < 25
+            result = _run_context_tier(
+                sid, extra_env={"CLAUDE_CONTEXT_HEARTBEAT": "off"}
+            )
+            assert result.stdout.strip() == ""
+            assert _read_counter(sid) == 24
+        finally:
+            _cleanup_context_tier(sid)
+
+    def test_zero_env_falls_back_to_default(self):
+        sid = _context_tier_session_id("hb_zero")
+        try:
+            _write_sidecar(sid, "15")
+            _write_tier(sid, "low")
+            _write_counter(sid, 23)
+
+            result = _run_context_tier(sid, extra_env={"CLAUDE_CONTEXT_HEARTBEAT": "0"})
+            assert result.stdout.strip() == ""
+            assert _read_counter(sid) == 24
         finally:
             _cleanup_context_tier(sid)
 


### PR DESCRIPTION
## Summary

- Add a periodic heartbeat to the `context-tier.sh` hook that re-injects tier guidance every 25 tool calls (configurable via `CLAUDE_CONTEXT_HEARTBEAT`), even when the tier hasn't changed — previously the hook only emitted on tier transitions, leaving 700+ tool calls between reassurances during long orchestrations
- Motivated by session `995aeb39` where Claude fabricated context pressure at 25% usage and skipped code reviews on 4 of 7 WPs because the "continue working normally" message had scrolled out of context
- Includes numeric validation for the env var, updated docs (README, performance rule), and 4 new test cases covering heartbeat firing, counter reset on tier change, and invalid env var fallback
