### PR TITLE
feat(tmux): add session-name drift check hook

### DIFF
--- a/install.py
+++ b/install.py
@@ -97,8 +97,8 @@ HOOK_GROUPS: dict[str, HookGroup] = {
     ),
     "tmux": HookGroup(
         label="Tmux",
-        description="Session naming reminders",
-        files=("tmux-remind.sh",),
+        description="Session naming reminders and drift detection",
+        files=("tmux-remind.sh", "tmux-drift-check.sh"),
     ),
     "context": HookGroup(
         label="Context awareness",

--- a/rules/common/tmux.md
+++ b/rules/common/tmux.md
@@ -28,9 +28,15 @@ Rules:
 - No spaces or special characters beyond hyphens
 - Prefer branch name if it's already descriptive
 
+## Terminal Tab Title (Bedrock Only)
+
+On Bedrock, Claude Code's auto-title generation is broken (output_config rejected by Bedrock API). The workaround is in `tmux.conf`: when `CLAUDE_CODE_USE_BEDROCK=1`, `set-titles-string` uses `#{session_name}` instead of `#{pane_title}`. Claude Code's spinner constantly overwrites the pane title but never touches the session name, so the tab always reflects the session name set by `claude-tmux rename`. No sidecar files or extra hooks needed — just renaming the session is sufficient.
+
 ## Drift Detection
 
 When the conversation topic shifts significantly (e.g., pivoting from one feature to another), update the session name to match the new focus.
+
+A `PreToolUse` hook (`tmux-drift-check.sh`) fires every ~30 tool calls inside tmux sessions, reporting the current session name and prompting a rename if the topic has shifted. The interval is configurable via `CLAUDE_TMUX_DRIFT_HEARTBEAT`.
 
 ## Cross-Pane Monitoring
 

--- a/scripts/hooks/tmux-drift-check.sh
+++ b/scripts/hooks/tmux-drift-check.sh
@@ -19,19 +19,19 @@ case "$heartbeat_interval" in
 esac
 
 counter_file="/tmp/claude-tmux-drift-${session_id}.txt"
-count="$(cat "$counter_file" 2>/dev/null)" || true
+count="$(cat "$counter_file" 2> /dev/null)" || true
 count="${count:-0}"
 case "$count" in *[!0-9]*) count=0 ;; esac
 count=$((count + 1))
 
-printf '%d' "$count" > "${counter_file}.tmp" 2>/dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2>/dev/null || true
+printf '%d' "$count" > "${counter_file}.tmp" 2> /dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2> /dev/null || true
 
 [ "$count" -ge "$heartbeat_interval" ] || exit 0
 
 # Reset counter
-printf '0' > "${counter_file}.tmp" 2>/dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2>/dev/null || true
+printf '0' > "${counter_file}.tmp" 2> /dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2> /dev/null || true
 
-session_name="$(tmux display-message -p '#{session_name}' 2>/dev/null)" || exit 0
+session_name="$(tmux display-message -p '#{session_name}' 2> /dev/null)" || exit 0
 [ -n "$session_name" ] || exit 0
 
 jq -cn --arg name "$session_name" \

--- a/scripts/hooks/tmux-drift-check.sh
+++ b/scripts/hooks/tmux-drift-check.sh
@@ -6,11 +6,20 @@
 # an extra tool call.
 #
 # Hook wiring: add as a "PreToolUse" entry with matcher "*" in settings.json.
+#
+# No set -euo pipefail — this hook is a sequence of guard clauses that each
+# exit 0 on failure.
+
+if ! command -v jq > /dev/null 2>&1; then
+  exit 0
+fi
 
 [ -n "${TMUX:-}" ] || exit 0
 
-session_id="${CLAUDE_CODE_SESSION_ID:-}"
-[ -n "$session_id" ] || exit 0
+input="$(cat || true)"
+
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty' 2> /dev/null)" || true
+case "$session_id" in '' | *[/.]*) exit 0 ;; esac
 
 heartbeat_interval="${CLAUDE_TMUX_DRIFT_HEARTBEAT:-30}"
 # 0 is rejected — use CLAUDE_TMUX_DRIFT_HEARTBEAT=1 for maximum frequency; 0 would fire every call

--- a/scripts/hooks/tmux-drift-check.sh
+++ b/scripts/hooks/tmux-drift-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# PreToolUse hook: periodically remind Claude to check the tmux session name for drift.
+#
+# Fires every N tool calls (default 30, override via CLAUDE_TMUX_DRIFT_HEARTBEAT).
+# Embeds the current session name in the message so Claude can judge drift without
+# an extra tool call.
+#
+# Hook wiring: add as a "PreToolUse" entry with matcher "*" in settings.json.
+
+[ -n "${TMUX:-}" ] || exit 0
+
+session_id="${CLAUDE_CODE_SESSION_ID:-}"
+[ -n "$session_id" ] || exit 0
+
+heartbeat_interval="${CLAUDE_TMUX_DRIFT_HEARTBEAT:-30}"
+# 0 is rejected — use CLAUDE_TMUX_DRIFT_HEARTBEAT=1 for maximum frequency; 0 would fire every call
+case "$heartbeat_interval" in
+  '' | *[!0-9]* | 0) heartbeat_interval=30 ;;
+esac
+
+counter_file="/tmp/claude-tmux-drift-${session_id}.txt"
+count="$(cat "$counter_file" 2>/dev/null)" || true
+count="${count:-0}"
+case "$count" in *[!0-9]*) count=0 ;; esac
+count=$((count + 1))
+
+printf '%d' "$count" > "${counter_file}.tmp" 2>/dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2>/dev/null || true
+
+[ "$count" -ge "$heartbeat_interval" ] || exit 0
+
+# Reset counter
+printf '0' > "${counter_file}.tmp" 2>/dev/null && mv -f "${counter_file}.tmp" "$counter_file" 2>/dev/null || true
+
+session_name="$(tmux display-message -p '#{session_name}' 2>/dev/null)" || exit 0
+[ -n "$session_name" ] || exit 0
+
+jq -cn --arg name "$session_name" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":("Session name check: current name is \($name). If the topic has shifted significantly, update it with: claude-tmux rename \"new-name\"")}}'

--- a/settings.json
+++ b/settings.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "bash -c 'f=\"${CLAUDE_HOME:-$HOME/.claude}/scripts/hooks/context-tier.sh\"; [ -x \"$f\" ] && exec \"$f\" || exit 0'",
             "timeout": 2000
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'f=\"${CLAUDE_HOME:-$HOME/.claude}/scripts/hooks/tmux-drift-check.sh\"; [ -x \"$f\" ] && exec \"$f\" || exit 0'",
+            "timeout": 2000
           }
         ]
       }

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1306,22 +1306,25 @@ def _run_drift_check(
     env["TMUX"] = "/tmp/tmux-stub,1,0"
     if tmux_stub_dir:
         env["PATH"] = str(tmux_stub_dir) + ":" + env.get("PATH", "")
+        stub_ctx = None
     else:
-        # Default: create a temp stub inline
-        import tempfile as _tempfile
-
-        _td = Path(_tempfile.mkdtemp())
+        stub_ctx = tempfile.TemporaryDirectory()
+        _td = Path(stub_ctx.name)
         _make_tmux_stub(_td, session_name)
         env["PATH"] = str(_td) + ":" + env.get("PATH", "")
     if extra_env:
         env.update(extra_env)
-    return subprocess.run(
-        [str(DRIFT_CHECK_HOOK)],
-        input=json.dumps({"session_id": session_id}),
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    try:
+        return subprocess.run(
+            [str(DRIFT_CHECK_HOOK)],
+            input=json.dumps({"session_id": session_id}),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    finally:
+        if stub_ctx is not None:
+            stub_ctx.cleanup()
 
 
 class TestTmuxDriftCheckSilentBelowInterval:
@@ -1466,15 +1469,20 @@ class TestTmuxDriftCheckHeartbeatConfig:
     """Heartbeat interval env var edge cases."""
 
     def test_zero_interval_falls_back_to_default(self):
+        # CLAUDE_TMUX_DRIFT_HEARTBEAT=0 is rejected; the hook falls back to 30.
+        # With counter at 29, the next call brings it to 30 (>= 30), so the hook fires.
         sid = _drift_session_id("zero_interval")
         try:
-            _write_drift_counter(sid, 29)  # fires at 30 (default), not 0
+            _write_drift_counter(sid, 29)
             result = _run_drift_check(
-                sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "0"}
+                sid,
+                session_name="zero-fallback-session",
+                extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "0"},
             )
             assert result.returncode == 0
-            # Should be silent — counter 30 < default 30 hasn't fired yet (30 >= 30 fires)
-            # Actually 29+1=30 >= 30, so it fires. Confirm counter reset to 0.
+            output = json.loads(result.stdout)
+            context = output["hookSpecificOutput"]["additionalContext"]
+            assert "zero-fallback-session" in context
             assert _read_drift_counter(sid) == 0
         finally:
             _cleanup_drift(sid)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1340,7 +1340,9 @@ class TestTmuxDriftCheckSilentBelowInterval:
         sid = _drift_session_id("below_interval")
         try:
             _write_drift_counter(sid, 27)  # will become 28, threshold is 30
-            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "30"})
+            result = _run_drift_check(
+                sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "30"}
+            )
             assert result.returncode == 0
             assert result.stdout.strip() == ""
             assert _read_drift_counter(sid) == 28
@@ -1390,7 +1392,9 @@ class TestTmuxDriftCheckEmitsAtThreshold:
         sid = _drift_session_id("custom_interval")
         try:
             _write_drift_counter(sid, 4)  # will become 5, fires at interval=5
-            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "5"})
+            result = _run_drift_check(
+                sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "5"}
+            )
             assert result.returncode == 0
             assert result.stdout.strip() != ""
         finally:
@@ -1465,7 +1469,9 @@ class TestTmuxDriftCheckHeartbeatConfig:
         sid = _drift_session_id("zero_interval")
         try:
             _write_drift_counter(sid, 29)  # fires at 30 (default), not 0
-            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "0"})
+            result = _run_drift_check(
+                sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "0"}
+            )
             assert result.returncode == 0
             # Should be silent — counter 30 < default 30 hasn't fired yet (30 >= 30 fires)
             # Actually 29+1=30 >= 30, so it fires. Confirm counter reset to 0.
@@ -1477,7 +1483,9 @@ class TestTmuxDriftCheckHeartbeatConfig:
         sid = _drift_session_id("invalid_interval")
         try:
             _write_drift_counter(sid, 5)
-            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "abc"})
+            result = _run_drift_check(
+                sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "abc"}
+            )
             assert result.returncode == 0
             assert result.stdout.strip() == ""  # 6 < 30 default
         finally:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1256,3 +1256,229 @@ class TestContextTierPathTraversal:
 
         assert result.returncode == 0
         assert result.stdout.strip() == ""
+
+
+# tmux-drift-check.sh tests
+# ---------------------------------------------------------------------------
+
+DRIFT_CHECK_HOOK = REPO_ROOT / "scripts" / "hooks" / "tmux-drift-check.sh"
+
+
+def _drift_session_id(test_name: str) -> str:
+    return f"drift-test-{test_name}-{uuid.uuid4().hex[:8]}"
+
+
+def _write_drift_counter(session_id: str, count: int) -> Path:
+    p = Path(f"/tmp/claude-tmux-drift-{session_id}.txt")
+    p.write_text(str(count))
+    return p
+
+
+def _read_drift_counter(session_id: str) -> int | None:
+    p = Path(f"/tmp/claude-tmux-drift-{session_id}.txt")
+    if not p.exists():
+        return None
+    text = p.read_text().strip()
+    return int(text) if text else None
+
+
+def _cleanup_drift(session_id: str) -> None:
+    p = Path(f"/tmp/claude-tmux-drift-{session_id}.txt")
+    if p.exists():
+        p.unlink()
+
+
+def _make_tmux_stub(tmpdir: Path, session_name: str) -> Path:
+    """Write a tmux stub script that prints session_name for display-message."""
+    stub = tmpdir / "tmux"
+    stub.write_text(f'#!/usr/bin/env bash\necho "{session_name}"\n')
+    stub.chmod(0o755)
+    return stub
+
+
+def _run_drift_check(
+    session_id: str,
+    session_name: str = "test-session",
+    extra_env: dict[str, str] | None = None,
+    tmux_stub_dir: Path | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["TMUX"] = "/tmp/tmux-stub,1,0"
+    if tmux_stub_dir:
+        env["PATH"] = str(tmux_stub_dir) + ":" + env.get("PATH", "")
+    else:
+        # Default: create a temp stub inline
+        import tempfile as _tempfile
+
+        _td = Path(_tempfile.mkdtemp())
+        _make_tmux_stub(_td, session_name)
+        env["PATH"] = str(_td) + ":" + env.get("PATH", "")
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(DRIFT_CHECK_HOOK)],
+        input=json.dumps({"session_id": session_id}),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestTmuxDriftCheckSilentBelowInterval:
+    """Hook stays silent while counter is below the heartbeat interval."""
+
+    def test_first_call_silent(self):
+        sid = _drift_session_id("first_silent")
+        try:
+            result = _run_drift_check(sid)
+            assert result.returncode == 0
+            assert result.stdout.strip() == ""
+        finally:
+            _cleanup_drift(sid)
+
+    def test_below_interval_silent(self):
+        sid = _drift_session_id("below_interval")
+        try:
+            _write_drift_counter(sid, 27)  # will become 28, threshold is 30
+            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "30"})
+            assert result.returncode == 0
+            assert result.stdout.strip() == ""
+            assert _read_drift_counter(sid) == 28
+        finally:
+            _cleanup_drift(sid)
+
+    def test_counter_increments_each_call(self):
+        sid = _drift_session_id("increments")
+        try:
+            _write_drift_counter(sid, 5)
+            _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "30"})
+            assert _read_drift_counter(sid) == 6
+        finally:
+            _cleanup_drift(sid)
+
+
+class TestTmuxDriftCheckEmitsAtThreshold:
+    """Hook emits session name context at the heartbeat threshold."""
+
+    def test_emits_at_threshold(self):
+        sid = _drift_session_id("at_threshold")
+        try:
+            _write_drift_counter(sid, 29)  # will become 30, fires
+            result = _run_drift_check(
+                sid,
+                session_name="myapp-feature",
+                extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "30"},
+            )
+            assert result.returncode == 0
+            output = json.loads(result.stdout)
+            context = output["hookSpecificOutput"]["additionalContext"]
+            assert "myapp-feature" in context
+            assert "claude-tmux rename" in context
+        finally:
+            _cleanup_drift(sid)
+
+    def test_counter_resets_after_firing(self):
+        sid = _drift_session_id("resets")
+        try:
+            _write_drift_counter(sid, 29)
+            _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "30"})
+            assert _read_drift_counter(sid) == 0
+        finally:
+            _cleanup_drift(sid)
+
+    def test_custom_heartbeat_interval(self):
+        sid = _drift_session_id("custom_interval")
+        try:
+            _write_drift_counter(sid, 4)  # will become 5, fires at interval=5
+            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "5"})
+            assert result.returncode == 0
+            assert result.stdout.strip() != ""
+        finally:
+            _cleanup_drift(sid)
+
+
+class TestTmuxDriftCheckNoTmux:
+    """Hook exits silently when not inside tmux."""
+
+    def test_no_tmux_env_silent(self):
+        sid = _drift_session_id("no_tmux")
+        env = os.environ.copy()
+        env.pop("TMUX", None)
+        result = subprocess.run(
+            [str(DRIFT_CHECK_HOOK)],
+            input=json.dumps({"session_id": sid}),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+class TestTmuxDriftCheckInvalidSessionId:
+    """Hook rejects session IDs with path-unsafe characters."""
+
+    def test_slash_in_session_id_silent(self):
+        env = os.environ.copy()
+        env["TMUX"] = "/tmp/tmux-stub,1,0"
+        result = subprocess.run(
+            [str(DRIFT_CHECK_HOOK)],
+            input=json.dumps({"session_id": "foo/bar"}),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_dot_in_session_id_silent(self):
+        env = os.environ.copy()
+        env["TMUX"] = "/tmp/tmux-stub,1,0"
+        result = subprocess.run(
+            [str(DRIFT_CHECK_HOOK)],
+            input=json.dumps({"session_id": "foo.bar"}),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_empty_session_id_silent(self):
+        env = os.environ.copy()
+        env["TMUX"] = "/tmp/tmux-stub,1,0"
+        result = subprocess.run(
+            [str(DRIFT_CHECK_HOOK)],
+            input=json.dumps({"session_id": ""}),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+class TestTmuxDriftCheckHeartbeatConfig:
+    """Heartbeat interval env var edge cases."""
+
+    def test_zero_interval_falls_back_to_default(self):
+        sid = _drift_session_id("zero_interval")
+        try:
+            _write_drift_counter(sid, 29)  # fires at 30 (default), not 0
+            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "0"})
+            assert result.returncode == 0
+            # Should be silent — counter 30 < default 30 hasn't fired yet (30 >= 30 fires)
+            # Actually 29+1=30 >= 30, so it fires. Confirm counter reset to 0.
+            assert _read_drift_counter(sid) == 0
+        finally:
+            _cleanup_drift(sid)
+
+    def test_invalid_interval_falls_back_to_default(self):
+        sid = _drift_session_id("invalid_interval")
+        try:
+            _write_drift_counter(sid, 5)
+            result = _run_drift_check(sid, extra_env={"CLAUDE_TMUX_DRIFT_HEARTBEAT": "abc"})
+            assert result.returncode == 0
+            assert result.stdout.strip() == ""  # 6 < 30 default
+        finally:
+            _cleanup_drift(sid)


### PR DESCRIPTION
## Summary

On Bedrock, Claude Code's spinner dominates `pane_title` and auto-title generation is broken. The fix lives in `tmux.conf` (Dotfiles repo): use `#{session_name}` as `set-titles-string` when `CLAUDE_CODE_USE_BEDROCK=1`.

This PR adds the Claudefiles side:

### Changes

- **`scripts/hooks/tmux-drift-check.sh`** (new): PreToolUse hook that fires every ~30 tool calls inside tmux sessions. Embeds the current session name and reminds Claude to rename if the topic has shifted. Active on all machines — meaningful session names are useful everywhere, not just Bedrock. Interval configurable via `CLAUDE_TMUX_DRIFT_HEARTBEAT`.
- **`settings.json`**: wire `tmux-drift-check.sh` into the PreToolUse `*` matcher
- **`rules/common/tmux.md`**: document the Bedrock tab-title workaround and the drift-check hook

### What was removed (not tracked in Claudefiles)

The sidecar-file approach (`session-title.sh`, `session-title-remind.sh`, `session-title-stop.sh`, `UserPromptSubmit` hook) was explored and abandoned — Claude Code's spinner overwrites the pane title after every response regardless of hook timing. Session name is the correct lever.