### PR TITLE
feat(cm): session filter + tighten memory consolidation agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this Claudefiles repository are documented here.
 
+## 2026-05-15
+
+### Added
+- `--session UUID` flag on `cm-recent-chats` and `cm-search-conversations` — filter by session UUID prefix match for targeted retrieval
+
+### Changed
+- Signal discoverer agent is now report-only — no longer writes memory files directly; orchestrator handles all writes after user approval
+- Memory auditor gains COMPLETED category — flags project memories about finished work for removal instead of updating them to say "done"
+- Signal discoverer quality bar raised: rejection patterns section, 3-5 candidate target (down from 6-10), `Bash(python3:*)` replaced with `Bash(cm-recent-chats:*)`
+- Memory auditor worktree-awareness: checks `git log origin/<default-branch>` before flagging files as STALE when running in a branch behind default
+
 ## 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this Claudefiles repository are documented here.
 ## 2026-05-15
 
 ### Added
-- `--session UUID` flag on `cm-recent-chats` and `cm-search-conversations` — filter by session UUID prefix match for targeted retrieval
+- `--session UUID` flag on `cm-recent-chats` and `cm-search-conversations` — filter by session UUID prefix match for targeted retrieval (#295)
 
 ### Changed
-- Signal discoverer agent is now report-only — no longer writes memory files directly; orchestrator handles all writes after user approval
-- Memory auditor gains COMPLETED category — flags project memories about finished work for removal instead of updating them to say "done"
-- Signal discoverer quality bar raised: rejection patterns section, 3-5 candidate target (down from 6-10), `Bash(python3:*)` replaced with `Bash(cm-recent-chats:*)`
-- Memory auditor worktree-awareness: checks `git log origin/<default-branch>` before flagging files as STALE when running in a branch behind default
+- Signal discoverer agent is now report-only — no longer writes memory files directly; orchestrator handles all writes after user approval (#295)
+- Memory auditor gains COMPLETED category — flags project memories about finished work for removal instead of updating them to say "done" (#295)
+- Signal discoverer quality bar raised: rejection patterns section, 3-5 candidate target (down from 6-10), `Bash(python3:*)` replaced with `Bash(cm-recent-chats:*)` (#295)
+- Memory auditor worktree-awareness: checks `git log origin/<default-branch>` before flagging files as STALE when running in a branch behind default (#295)
 
 ## 2026-05-14
 

--- a/agents/cm-memory-auditor.md
+++ b/agents/cm-memory-auditor.md
@@ -26,11 +26,12 @@ targets (file paths, function names, version numbers, patterns named in memories
 these are missing from the prompt, work with what you have — read the memory files yourself if
 needed.
 
-Update your agent memory as you discover recurring staleness patterns, paths that frequently
-move, and conventions that have shifted. Record which entries have been previously verified
-and their status, so future runs can focus on new or changed entries. Use `Read` to check
-existing memory before writing, and `Write`/`Edit` to update it. Each run, append a brief
-entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX/REDUNDANT: N each).
+**You are a reporter, not a writer.** Do NOT create, edit, or write any project memory
+files. Your only output is a structured findings report returned to the caller. The caller
+handles user approval and file writes.
+
+Update your own agent memory with recurring staleness patterns and verification history,
+so future runs can focus on new or changed entries.
 
 ## Process
 
@@ -51,7 +52,13 @@ entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX
 4. Scan for relative dates in memory entries — "yesterday", "recently", "last week", "this
    morning". These decay into meaninglessness. Flag each for conversion to an absolute date.
 
-5. Check for code-redundant entries. For each memory that states a specific value,
+5. Check for completed work. Project-type memories that describe in-progress work,
+   active incidents, or ongoing initiatives should be checked against git history and
+   current code. If the work is done (merged, shipped, closed), flag as REMOVE — do NOT
+   update the memory to say "completed" or "resolved". A memory about finished work has
+   zero future utility; it just adds index noise. The git history preserves the record.
+
+6. Check for code-redundant entries. For each memory that states a specific value,
    configuration, constant, version, or count — check whether the source file containing
    that information is readable in the codebase. If the memory adds no rationale, gotcha,
    or design decision beyond what's visible in the source, flag as REDUNDANT.
@@ -67,7 +74,7 @@ entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX
    memory connects facts from multiple sources — is not redundant even if each
    individual fact is readable.
 
-6. Identify merge opportunities — memory entries that cover overlapping ground and could be
+7. Identify merge opportunities — memory entries that cover overlapping ground and could be
    combined into a single, stronger entry. Merge criteria: both entries must currently exist,
    reference the same entity or decision, overlap in content by more than 50%, and a single
    merged entry must be strictly shorter than the two originals combined.
@@ -77,7 +84,7 @@ entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX
 Return a structured list of findings. Each finding has:
 
 ```
-Category: STALE | CONTRADICT | MERGE | DATE_FIX | REDUNDANT
+Category: STALE | CONTRADICT | COMPLETED | MERGE | DATE_FIX | REDUNDANT
 Memory file: <filename>
 Entry: "<quoted text from the memory>"
 Evidence: <what you found — the Glob/Grep/git result that proves the issue>
@@ -105,6 +112,9 @@ names — all current").
   /etc/docker/daemon.json) may still be worth keeping since they're outside the project tree.
 - For REDUNDANT findings, default to REMOVE — there is no edited form of a code-readable
   fact that isn't still redundant.
+- For COMPLETED findings, always REMOVE. Never edit a project memory to say "completed",
+  "resolved", "shipped", or "done" — that turns a useful memory into a historical record
+  with no future utility. Git history serves that purpose.
 
 ## Edge Cases
 
@@ -116,3 +126,9 @@ names — all current").
   checkable entities — report this explicitly and skip to date scan.
 - All entries verified clean: report "No issues detected" with the
   full verification summary; do not manufacture findings.
+- Running in a worktree or feature branch: the working tree may be behind the default
+  branch. Before flagging a file path as STALE, run
+  `git log --oneline origin/<default-branch> -- <path>` to check if the file exists on
+  the default branch. If it was added there after this branch diverged, it's not stale —
+  just missing from this checkout. Note this in the finding rather than reporting it as
+  STALE.

--- a/agents/cm-memory-auditor.md
+++ b/agents/cm-memory-auditor.md
@@ -50,9 +50,9 @@ approval and all file writes.
 
 5. Check for completed work. Project-type memories that describe in-progress work,
    active incidents, or ongoing initiatives should be checked against git history and
-   current code. If the work is done (merged, shipped, closed), flag as REMOVE — do NOT
-   update the memory to say "completed" or "resolved". A memory about finished work has
-   zero future utility; it just adds index noise. The git history preserves the record.
+   current code. If the work is done (merged, shipped, closed), flag as COMPLETED with
+   suggested action REMOVE. Do NOT update the memory to say "completed" or "resolved".
+   A memory about finished work has zero future utility; git history preserves the record.
 
 6. Check for code-redundant entries. For each memory that states a specific value,
    configuration, constant, version, or count — check whether the source file containing

--- a/agents/cm-memory-auditor.md
+++ b/agents/cm-memory-auditor.md
@@ -8,7 +8,6 @@ description: >
   large refactors or version bumps.
 model: inherit
 color: blue
-memory: project
 effort: medium
 tools:
   - Read
@@ -26,12 +25,9 @@ targets (file paths, function names, version numbers, patterns named in memories
 these are missing from the prompt, work with what you have — read the memory files yourself if
 needed.
 
-**You are a reporter, not a writer.** Do NOT create, edit, or write any project memory
-files. Your only output is a structured findings report returned to the caller. The caller
-handles user approval and file writes.
-
-Update your own agent memory with recurring staleness patterns and verification history,
-so future runs can focus on new or changed entries.
+**You are a reporter, not a writer.** Do NOT create, edit, or write any files. Your only
+output is a structured findings report returned to the caller. The caller handles user
+approval and all file writes.
 
 ## Process
 

--- a/agents/cm-signal-discoverer.md
+++ b/agents/cm-signal-discoverer.md
@@ -12,7 +12,8 @@ effort: medium
 tools:
   - Read
   - Glob
-  - Bash(python3:*)
+  - Bash(cm-recent-chats:*)
+  - Bash(ls:*)
   - Bash(git:*)
   - Bash(find:*)
 maxTurns: 35
@@ -21,6 +22,11 @@ maxTurns: 35
 You are a signal extraction specialist. Your job is to mine recent conversation sessions for
 knowledge worth persisting to memory — user corrections, architectural decisions, recurring
 patterns, and behavioral preferences that a future session would benefit from knowing.
+
+**You are a reporter, not a writer.** Do NOT create, edit, or write any memory files
+(topic files, MEMORY.md, or any .md files in the project memory directory). Your only
+output is a structured findings report returned to the caller. The caller handles user
+approval and file writes.
 
 Your caller provides you with: existing memory summaries (so you can avoid duplicates) and a
 project name. If the project name is missing, infer it from the current working directory.
@@ -99,6 +105,41 @@ patterns already captured in existing memories").
   rationale for a decision, a gotcha discovered through debugging, or a constraint that
   isn't obvious from reading the implementation.
 
+## Rejection Patterns (learned from user feedback)
+
+These patterns have been repeatedly rejected during consolidation. Do NOT propose
+candidates that match these shapes:
+
+1. **One-off environmental flukes.** If the issue required a specific broken state that
+   has since been fixed and is unlikely to recur (e.g., a transient GPG key error, a
+   one-time package conflict), it's noise. The test: "Could this happen again in a
+   normal workflow?" If no, skip it.
+
+2. **Hyper-specific corrections with no recurring risk.** A user correction like "don't
+   reformat vendored code" only matters if there's ongoing vendored code that Claude
+   interacts with regularly. If the correction addressed a one-time mistake on a specific
+   file that won't be touched again, it's noise. The test: "Is there a surface area
+   where this mistake could recur?"
+
+3. **Library/tool behavior that's in the docs.** How boto3 resolves credentials, how
+   git rebase works, how a specific API behaves — these are discoverable from docs or
+   code. Only save if there's a non-obvious gotcha that contradicts documentation or
+   common assumptions.
+
+4. **Changelog/housekeeping rules.** "Don't add empty changelog entries" or similar
+   process nits that are better enforced by tooling (pre-commit hooks, CI) than by
+   memory. If it can be automated, it shouldn't be a memory.
+
+5. **Corrections from the current session being consolidated.** The signal discoverer
+   runs inside a consolidation session. Do not propose memories from exchanges that
+   are part of the consolidation itself — only from the sessions being scanned.
+
+### Calibration: prefer fewer, higher-quality candidates
+
+Aim for 3-5 candidates per consolidation run, not 6-10. A consolidation that proposes
+10 memories is almost certainly including noise. Apply the rejection patterns above
+aggressively. The user can always ask for more if the initial set seems thin.
+
 ## Edge Cases
 
 - Recall script not found at expected path: report "cm-recent-chats not found in PATH — run `uv tool install -e packages/claude-memory` to install the claude-memory package" and stop.
@@ -110,10 +151,9 @@ patterns already captured in existing memories").
 Your agent memory tracks signal-discovery coverage: which sessions have been analyzed,
 which candidates were surfaced, and which were accepted or rejected by the caller.
 
-After each run, append to your agent MEMORY.md (path provided by the memory system):
+After each run, update your own agent memory (provided by the memory system) with:
 - Session range scanned (e.g., "Scanned 10 sessions: 2026-04-01 to 2026-04-07")
 - Candidate count by category (UPDATE: N, CONTRADICT: N, FILL_GAP: N, NOISE: N)
-- Any candidates the caller explicitly accepted or declined (for dedup on future runs)
 
-Use `Read` to check existing memory before writing, and `Write`/`Edit` to update it.
-Use this on subsequent runs to avoid re-surfacing already-reviewed candidates.
+This is your internal tracking only. Do NOT write to the project's memory directory —
+that is the orchestrator's responsibility after user approval.

--- a/agents/cm-signal-discoverer.md
+++ b/agents/cm-signal-discoverer.md
@@ -7,7 +7,6 @@ description: >
   preferences. Not for persisting memories — use extract-learnings for that.
 model: inherit
 color: cyan
-memory: project
 effort: medium
 tools:
   - Read
@@ -146,14 +145,3 @@ aggressively. The user can always ask for more if the initial set seems thin.
 - Project name cannot be inferred from cwd (no git root, no recognizable project name):
   ask the caller to supply the project name before running the recall script.
 
-## Agent Memory
-
-Your agent memory tracks signal-discovery coverage: which sessions have been analyzed,
-which candidates were surfaced, and which were accepted or rejected by the caller.
-
-After each run, update your own agent memory (provided by the memory system) with:
-- Session range scanned (e.g., "Scanned 10 sessions: 2026-04-01 to 2026-04-07")
-- Candidate count by category (UPDATE: N, CONTRADICT: N, FILL_GAP: N, NOISE: N)
-
-This is your internal tracking only. Do NOT write to the project's memory directory —
-that is the orchestrator's responsibility after user approval.

--- a/agents/cm-signal-discoverer.md
+++ b/agents/cm-signal-discoverer.md
@@ -12,7 +12,6 @@ tools:
   - Read
   - Glob
   - Bash(cm-recent-chats:*)
-  - Bash(ls:*)
   - Bash(git:*)
   - Bash(find:*)
 maxTurns: 35
@@ -35,7 +34,7 @@ project name. If the project name is missing, infer it from the current working 
 1. Run the recall script directly — it's an installed entry point:
    `cm-recent-chats --n 10 --project <project-name> --verbose`
 
-3. Analyze each session for high-signal content. Look specifically for:
+2. Analyze each session for high-signal content. Look specifically for:
    - User corrections ("no, not that", "don't do X", "stop doing Y") — these indicate
      behavioral preferences the agent should internalize
    - Architectural decisions with rationale ("we chose X because Y") — these prevent
@@ -47,7 +46,7 @@ project name. If the project name is missing, infer it from the current working 
    - Configuration discoveries — settings, flags, or workarounds found through trial and
      error that aren't documented elsewhere
 
-4. For each finding, generalize to a principle. This is the critical step. Do not record
+3. For each finding, generalize to a principle. This is the critical step. Do not record
    incidents — record the principle behind them.
 
    Incident (bad): "In the March 15 session, we spent 30 minutes debugging why the hook
@@ -56,7 +55,7 @@ project name. If the project name is missing, infer it from the current working 
    Principle (good): "Strip CLAUDECODE env var before spawning claude -p subprocesses —
    the nesting guard only matters for interactive sessions, not programmatic invocations."
 
-5. Classify each finding:
+4. Classify each finding:
    - UPDATE: modifies something already in existing memories (something changed)
    - CONTRADICT: conflicts with an existing memory (something was wrong)
    - FILL_GAP: important knowledge with no existing entry

--- a/packages/claude-memory/src/claude_memory/recent_chats.py
+++ b/packages/claude-memory/src/claude_memory/recent_chats.py
@@ -50,7 +50,9 @@ def get_recent_sessions(
 
     if session_id:
         sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-        escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        escaped = (
+            session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
         params.append(f"{escaped}%")
 
     if before:

--- a/packages/claude-memory/src/claude_memory/recent_chats.py
+++ b/packages/claude-memory/src/claude_memory/recent_chats.py
@@ -23,6 +23,7 @@ def get_recent_sessions(
     before: str | None = None,
     after: str | None = None,
     projects: list[str] | None = None,
+    session_id: str | None = None,
     verbose: bool = False,
     include_notifications: bool = False,
 ) -> list[dict]:
@@ -46,6 +47,11 @@ def get_recent_sessions(
         WHERE 1=1
     """
     params = []
+
+    if session_id:
+        sql += " AND s.uuid LIKE ? ESCAPE '\\'"
+        escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        params.append(f"{escaped}%")
 
     if before:
         sql += " AND b.started_at < ?"
@@ -169,6 +175,9 @@ def main():
     )
     parser.add_argument("--after", type=str, help="Sessions after this datetime (ISO)")
     parser.add_argument(
+        "--session", type=str, help="Filter by session UUID (prefix match)"
+    )
+    parser.add_argument(
         "--project", type=str, help="Filter by project name(s), comma-separated"
     )
     parser.add_argument(
@@ -217,6 +226,7 @@ def main():
             before=args.before,
             after=args.after,
             projects=projects,
+            session_id=args.session,
             verbose=args.verbose,
             include_notifications=args.include_notifications,
         )

--- a/packages/claude-memory/src/claude_memory/search_conversations.py
+++ b/packages/claude-memory/src/claude_memory/search_conversations.py
@@ -74,7 +74,9 @@ def search_sessions(
 
         if session_id:
             sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-            escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            escaped = (
+                session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            )
             params.append(f"{escaped}%")
 
         if fts_level == "fts5":
@@ -104,7 +106,9 @@ def search_sessions(
 
         if session_id:
             sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-            escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            escaped = (
+                session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            )
             params.append(f"{escaped}%")
 
         sql += " ORDER BY b.ended_at DESC LIMIT ?"

--- a/packages/claude-memory/src/claude_memory/search_conversations.py
+++ b/packages/claude-memory/src/claude_memory/search_conversations.py
@@ -23,6 +23,7 @@ def search_sessions(
     fts_level: str | None,
     max_results: int = 5,
     projects: list[str] | None = None,
+    session_id: str | None = None,
     verbose: bool = False,
     include_notifications: bool = False,
 ) -> list[dict]:
@@ -71,6 +72,11 @@ def search_sessions(
             sql += f" AND p.name IN ({placeholders})"
             params.extend(projects)
 
+        if session_id:
+            sql += " AND s.uuid LIKE ? ESCAPE '\\'"
+            escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            params.append(f"{escaped}%")
+
         if fts_level == "fts5":
             sql += " ORDER BY bm25(branches_fts) LIMIT ?"
         else:
@@ -95,6 +101,11 @@ def search_sessions(
             placeholders = ",".join("?" * len(projects))
             sql += f" AND p.name IN ({placeholders})"
             params.extend(projects)
+
+        if session_id:
+            sql += " AND s.uuid LIKE ? ESCAPE '\\'"
+            escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            params.append(f"{escaped}%")
 
         sql += " ORDER BY b.ended_at DESC LIMIT ?"
         params.append(max_results)
@@ -176,6 +187,9 @@ def main():
         "--max-results", type=int, default=5, help="Max sessions (1-10, default: 5)"
     )
     parser.add_argument(
+        "--session", type=str, help="Filter by session UUID (prefix match)"
+    )
+    parser.add_argument(
         "--project", type=str, help="Filter by project name(s), comma-separated"
     )
     parser.add_argument(
@@ -225,6 +239,7 @@ def main():
             fts_level=fts_level,
             max_results=max_results,
             projects=projects,
+            session_id=args.session,
             verbose=args.verbose,
             include_notifications=args.include_notifications,
         )

--- a/packages/claude-memory/tests/test_search.py
+++ b/packages/claude-memory/tests/test_search.py
@@ -213,7 +213,6 @@ class TestSearchSessionsFTS:
         assert session["messages"][0]["role"] == "user"
         assert session["messages"][1]["role"] == "assistant"
 
-
     def test_session_filter(self, search_db):
         fts_level = detect_fts_support(search_db)
         if fts_level not in ("fts5", "fts4"):

--- a/packages/claude-memory/tests/test_search.py
+++ b/packages/claude-memory/tests/test_search.py
@@ -1,10 +1,11 @@
-"""Tests for search_conversations.py — FTS5/FTS4/LIKE search cascade."""
+"""Tests for search_conversations.py and recent_chats.py — search and retrieval."""
 
 import sqlite3
 
 import pytest
 
 from claude_memory.search_conversations import search_sessions
+from claude_memory.recent_chats import get_recent_sessions
 from claude_memory.db import SCHEMA, _migrate_columns, detect_fts_support
 
 
@@ -213,6 +214,41 @@ class TestSearchSessionsFTS:
         assert session["messages"][1]["role"] == "assistant"
 
 
+    def test_session_filter(self, search_db):
+        fts_level = detect_fts_support(search_db)
+        if fts_level not in ("fts5", "fts4"):
+            pytest.skip("FTS not available")
+
+        results = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, session_id="sess-alpha-1"
+        )
+        assert len(results) == 1
+        assert results[0]["uuid"] == "sess-alpha-1"
+
+    def test_session_filter_prefix_match(self, search_db):
+        fts_level = detect_fts_support(search_db)
+        if fts_level not in ("fts5", "fts4"):
+            pytest.skip("FTS not available")
+
+        results = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, session_id="sess"
+        )
+        uuids = {r["uuid"] for r in results}
+        assert len(results) == 2
+        assert "sess-alpha-1" in uuids
+        assert "sess-beta-1" in uuids
+
+    def test_session_filter_no_match(self, search_db):
+        fts_level = detect_fts_support(search_db)
+        if fts_level not in ("fts5", "fts4"):
+            pytest.skip("FTS not available")
+
+        results = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, session_id="nonexistent"
+        )
+        assert len(results) == 0
+
+
 class TestSearchSessionsLIKE:
     """Test LIKE fallback when FTS is not available."""
 
@@ -246,6 +282,13 @@ class TestSearchSessionsLIKE:
     def test_like_max_results(self, search_db):
         results = search_sessions(search_db, "pytest", fts_level=None, max_results=1)
         assert len(results) <= 1
+
+    def test_like_session_filter(self, search_db):
+        results = search_sessions(
+            search_db, "pytest", fts_level=None, max_results=10, session_id="sess-beta"
+        )
+        assert len(results) == 1
+        assert results[0]["uuid"] == "sess-beta-1"
 
 
 class TestFtsSearchFindsFilePath:
@@ -347,3 +390,26 @@ class TestFtsSearchFindsFilePath:
         assert "sess-file-1" in uuids, (
             "LIKE search for 'summarizer' should find the session that edited summarizer.py"
         )
+
+
+class TestRecentChatsSessionFilter:
+    """Test --session filter on get_recent_sessions."""
+
+    def test_session_filter_exact(self, search_db):
+        results = get_recent_sessions(search_db, n=10, session_id="sess-alpha-1")
+        assert len(results) == 1
+        assert results[0]["uuid"] == "sess-alpha-1"
+
+    def test_session_filter_prefix(self, search_db):
+        results = get_recent_sessions(search_db, n=10, session_id="sess-alpha")
+        assert len(results) == 2
+        uuids = {r["uuid"] for r in results}
+        assert uuids == {"sess-alpha-1", "sess-alpha-2"}
+
+    def test_session_filter_no_match(self, search_db):
+        results = get_recent_sessions(search_db, n=10, session_id="nonexistent")
+        assert len(results) == 0
+
+    def test_session_filter_short_prefix(self, search_db):
+        results = get_recent_sessions(search_db, n=10, session_id="sess")
+        assert len(results) == 3

--- a/skills-memory/cm-extract-learnings/SKILL.md
+++ b/skills-memory/cm-extract-learnings/SKILL.md
@@ -36,7 +36,7 @@ Launch both agent calls in a single message so they run in parallel. Use the Age
 
 - **Memory Auditor**: `subagent_type: "cm-memory-auditor"`. In the `prompt`, include the context snapshot from Phase 1 — memory file contents, git log output, and verification targets list.
 
-- **Signal Discoverer**: `subagent_type: "cm-signal-discoverer"`. In the `prompt`, include existing memory summaries (for dedup) and the project name.
+- **Signal Discoverer**: `subagent_type: "cm-signal-discoverer"`. In the `prompt`, include existing memory summaries (for dedup) and the project name. Remind: "Report findings only — do not write any files."
 
 If Phase 1 noted MEMORY.md was just created (no existing memories), skip the Memory Auditor and spawn only the Signal Discoverer.
 
@@ -83,6 +83,14 @@ Phase 4 is complete when all approved edits are applied and the summary table is
 
 Every candidate must pass: (1) agent would benefit from knowing this in future sessions, (2) condensed to minimum useful form, (3) placed at correct layer, (4) not already captured in target file, (5) stated as reusable principle not session-specific incident.
 
-Pass: commands discovered through trial-and-error, non-obvious gotchas, architectural decisions with rationale, user behavioral corrections, configuration quirks, version milestones.
+Pass: commands discovered through trial-and-error, non-obvious gotchas, architectural decisions with rationale, user behavioral corrections that reflect recurring risk, configuration quirks, cross-cutting preferences confirmed across multiple sessions.
 
-Fail: information readable from code, generic best practices, one-off bugs without pattern, verbose explanations, duplicates, temporary state, unverified speculation, incidents without generalizable principle.
+Fail: information readable from code, generic best practices, one-off bugs without pattern, verbose explanations, duplicates, temporary state, unverified speculation, incidents without generalizable principle, library behavior that's in the docs, process rules better enforced by tooling, hyper-specific corrections for situations unlikely to recur.
+
+### Pruning at Proposal Time
+
+When reviewing Signal Discoverer output before presenting to the user, actively prune:
+- Candidates that address a one-time incident with no recurring surface area
+- Candidates where the "principle" is just a restatement of how a well-documented tool works
+- Candidates that could be a pre-commit hook or CI check instead of a memory
+- Aim for 3-5 proposals, not 6-10. Quality over quantity.

--- a/skills-memory/cm-extract-learnings/SKILL.md
+++ b/skills-memory/cm-extract-learnings/SKILL.md
@@ -34,7 +34,7 @@ Steps 2-4 are required and run as parallel tool calls.
 
 Launch both agent calls in a single message so they run in parallel. Use the Agent tool with:
 
-- **Memory Auditor**: `subagent_type: "cm-memory-auditor"`. In the `prompt`, include the context snapshot from Phase 1 — memory file contents, git log output, and verification targets list.
+- **Memory Auditor**: `subagent_type: "cm-memory-auditor"`. In the `prompt`, include the context snapshot from Phase 1 — memory file contents, git log output, and verification targets list. Remind: "Report findings only — do not write any files."
 
 - **Signal Discoverer**: `subagent_type: "cm-signal-discoverer"`. In the `prompt`, include existing memory summaries (for dedup) and the project name. Remind: "Report findings only — do not write any files."
 
@@ -48,7 +48,7 @@ Phase 2 is complete when both agents return reports. If either returns empty or 
 
 1. Receive agent reports
 2. Deduplicate across reports and against existing memories
-3. Rank by impact, limit to 3-7 candidates
+3. Rank by impact, limit to 3-5 candidates
 4. For each candidate: determine target layer, target section, action (ADD / EDIT / REMOVE)
 5. Read target files, check for duplicates
 6. Present proposals:

--- a/skills-memory/cm-recall-conversations/SKILL.md
+++ b/skills-memory/cm-recall-conversations/SKILL.md
@@ -52,6 +52,7 @@ cm-search-conversations --query "keyword"
    - Retrieve more sessions: `--n 20`
    - Search for specific terms that surfaced
    - Filter by project: `--project projectname`
+   - Filter by session: `--session <uuid-prefix>` (when a specific session ID is known)
    - If 2 rounds of deepening yield no new relevant sessions, synthesize from available data.
 
 ---

--- a/skills-memory/cm-recall-conversations/references/tool-reference.md
+++ b/skills-memory/cm-recall-conversations/references/tool-reference.md
@@ -14,6 +14,7 @@ cm-recent-chats --n 3
 | `--sort-order`            | 'desc' (newest first, default) or 'asc'                |
 | `--before DATE`           | Sessions before this datetime (ISO)                    |
 | `--after DATE`            | Sessions after this datetime (ISO)                     |
+| `--session UUID`          | Filter by session UUID (prefix match)                  |
 | `--project NAME`          | Filter by project name(s), comma-separated             |
 | `--verbose`               | Include files_modified and commits                     |
 | `--format`                | 'markdown' (default) or 'json'                         |
@@ -34,6 +35,7 @@ cm-search-conversations --query "keyword"
 |--------|--------|
 | `--query` | Required - substantive keywords |
 | `--max-results N` | Limit results (1-10, default 5) |
+| `--session UUID` | Filter by session UUID (prefix match) |
 | `--project NAME` | Filter by project name(s), comma-separated |
 | `--verbose` | Include files_modified and commits |
 | `--format` | 'markdown' (default) or 'json' |


### PR DESCRIPTION
## Summary

- Add `--session UUID` prefix-match flag to `cm-recent-chats` and `cm-search-conversations` for targeted session retrieval
- Make memory consolidation subagents (signal discoverer, memory auditor) report-only — they no longer write files directly; the orchestrator handles all writes after user approval
- Raise the signal discoverer's quality bar: explicit rejection patterns (one-off flukes, docs-derivable facts, automatable rules), 3-5 candidate target instead of 6-10, narrowed tool permissions (`Bash(python3:*)` → `Bash(cm-recent-chats:*)`)
- Add COMPLETED category to auditor — project memories about finished work get removed, not updated to say "done"
- Add worktree-awareness to auditor — checks `origin/<default-branch>` before flagging files as STALE
